### PR TITLE
Implement platform-specific navigation with bottom tab bars

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/my/composedemo/AndroidBottomNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/my/composedemo/AndroidBottomNavigation.kt
@@ -1,0 +1,85 @@
+package com.my.composedemo
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+// Android用のBottomNavigation
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AndroidBottomNavigation(
+    navigationState: NavigationState,
+    modifier: Modifier = Modifier
+) {
+    val selectedTab by navigationState.selectedTab.collectAsState()
+    
+    Scaffold(
+        bottomBar = {
+            NavigationBar(
+                modifier = modifier,
+                containerColor = MaterialTheme.colorScheme.surface,
+                tonalElevation = 8.dp
+            ) {
+                TabItem.values().forEach { tab ->
+                    NavigationBarItem(
+                        icon = {
+                            Icon(
+                                imageVector = tab.getAndroidIcon(),
+                                contentDescription = tab.title
+                            )
+                        },
+                        label = { Text(tab.title) },
+                        selected = selectedTab == tab,
+                        onClick = { navigationState.selectTab(tab) },
+                        colors = NavigationBarItemColors(
+                            selectedIconColor = MaterialTheme.colorScheme.primary,
+                            selectedTextColor = MaterialTheme.colorScheme.primary,
+                            unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            selectedIndicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                            disabledIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                            disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
+                    )
+                }
+            }
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            NavigationContent(
+                navigationState = navigationState
+            )
+        }
+    }
+}
+
+// TabItemのAndroidアイコン拡張
+fun TabItem.getAndroidIcon(): ImageVector {
+    return when (this) {
+        TabItem.HOME -> Icons.Default.Home
+        TabItem.SEARCH -> Icons.Default.Search
+        TabItem.PROFILE -> Icons.Default.Person
+        TabItem.SETTINGS -> Icons.Default.Settings
+    }
+}
+
+// Android用のメイン画面
+@Composable
+fun AndroidMainScreen(
+    navigationState: NavigationState,
+    onNavigateToNative: (() -> Unit)? = null
+) {
+    AndroidBottomNavigation(
+        navigationState = navigationState
+    )
+}

--- a/composeApp/src/androidMain/kotlin/com/my/composedemo/PlatformNavigation.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/my/composedemo/PlatformNavigation.android.kt
@@ -1,0 +1,16 @@
+package com.my.composedemo
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlatformNavigation(
+    navigationState: NavigationState,
+    onNavigateToNative: (() -> Unit)?,
+    onNavigateToSwiftUI: (() -> Unit)?
+) {
+    // Android用のBottomNavigationを使用
+    AndroidMainScreen(
+        navigationState = navigationState,
+        onNavigateToNative = onNavigateToNative
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/my/composedemo/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/my/composedemo/App.kt
@@ -48,84 +48,36 @@ fun App(
     onNavigateToSwiftUI: (() -> Unit)? = null,
     onNavigateToNative: (() -> Unit)? = null
 ) {
+    var appState by remember { mutableStateOf(AppState.SPLASH) }
+    val navigationState = remember { NavigationState() }
+    
     MaterialTheme {
-        var showCountries by remember { mutableStateOf(false) }
-        var timeAtLocation by remember { mutableStateOf("No location selected") }
-
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .padding(20.dp)
-                .safeContentPadding()
-                .fillMaxSize(),
-        ) {
-            Text(
-                timeAtLocation,
-                style = TextStyle(fontSize = 20.sp),
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
-            )
-            Row(
-                modifier = Modifier.padding(start = 20.dp, top = 10.dp)
-            ) {
-                DropdownMenu(
-                    expanded = showCountries,
-                    onDismissRequest = { showCountries = false }
-                ) {
-                    countries.forEach { (name, zone, image) ->
-                        DropdownMenuItem(
-                            text = {
-                                Row (
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Image(
-                                        painterResource(image),
-                                        modifier = Modifier.size(50.dp).padding(end = 10.dp),
-                                        contentDescription = "$name flag"
-                                    )
-                                    Text(name)
-                                }
-                            },
-                            onClick = {
-                                timeAtLocation = currentTimeAt(name, zone)
-                                showCountries = false
-                            }
-                        )
+        when (appState) {
+            AppState.SPLASH -> {
+                SplashScreen(
+                    onNavigateToHome = {
+                        appState = AppState.HOME
                     }
-                }
+                )
             }
-
-            Button(
-                onClick = {
-                    showCountries = !showCountries
-                },
-                modifier = Modifier.padding(start = 20.dp, top = 10.dp)
-            ) {
-                Text("Select Location")
-            }
-            
-            // SwiftUI画面への遷移ボタン
-            onNavigateToSwiftUI?.let { navigate ->
-                Button(
-                    onClick = navigate,
-                    modifier = Modifier.padding(start = 20.dp, top = 10.dp)
-                ) {
-                    Text("Open SwiftUI Screen")
-                }
-            }
-            
-            // Android Native画面への遷移ボタン
-            onNavigateToNative?.let { navigate ->
-                Button(
-                    onClick = navigate,
-                    modifier = Modifier.padding(start = 20.dp, top = 10.dp)
-                ) {
-                    Text("Open Android Native Screen")
-                }
+            AppState.HOME -> {
+                PlatformNavigation(
+                    navigationState = navigationState,
+                    onNavigateToNative = onNavigateToNative,
+                    onNavigateToSwiftUI = onNavigateToSwiftUI
+                )
             }
         }
     }
 }
+
+// プラットフォーム固有のナビゲーション
+@Composable
+expect fun PlatformNavigation(
+    navigationState: NavigationState,
+    onNavigateToNative: (() -> Unit)?,
+    onNavigateToSwiftUI: (() -> Unit)?
+)
 
 data class Country(
     val name: String,

--- a/composeApp/src/commonMain/kotlin/com/my/composedemo/NavigationState.kt
+++ b/composeApp/src/commonMain/kotlin/com/my/composedemo/NavigationState.kt
@@ -1,0 +1,164 @@
+package com.my.composedemo
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+// ナビゲーションのタブ定義
+enum class TabItem(val title: String, val icon: String) {
+    HOME("Home", "🏠"),
+    SEARCH("Search", "🔍"),
+    PROFILE("Profile", "👤"),
+    SETTINGS("Settings", "⚙️")
+}
+
+// 共通ナビゲーション状態管理
+class NavigationState {
+    private val _selectedTab = MutableStateFlow(TabItem.HOME)
+    val selectedTab: StateFlow<TabItem> = _selectedTab.asStateFlow()
+    
+    fun selectTab(tab: TabItem) {
+        _selectedTab.value = tab
+    }
+    
+    fun getCurrentTab(): TabItem = _selectedTab.value
+}
+
+// ナビゲーション用のコールバック定義
+interface NavigationCallbacks {
+    fun onNavigateToNativeTabBar()
+    fun onNavigateToSwiftUITabBar()
+}
+
+// 共通のナビゲーションコンテンツ
+@Composable
+fun NavigationContent(
+    navigationState: NavigationState,
+    onNavigateToNative: (() -> Unit)? = null,
+    onNavigateToSwiftUI: (() -> Unit)? = null
+) {
+    val selectedTab by navigationState.selectedTab.collectAsState()
+    
+    when (selectedTab) {
+        TabItem.HOME -> HomeScreen(
+            onNavigateToNative = onNavigateToNative,
+            onNavigateToSwiftUI = onNavigateToSwiftUI
+        )
+        TabItem.SEARCH -> SearchScreen()
+        TabItem.PROFILE -> ProfileScreen()
+        TabItem.SETTINGS -> SettingsScreen()
+    }
+}
+
+// 各画面のコンテンツ
+@Composable
+fun HomeScreen(
+    onNavigateToNative: (() -> Unit)? = null,
+    onNavigateToSwiftUI: (() -> Unit)? = null
+) {
+    androidx.compose.foundation.layout.Column(
+        modifier = androidx.compose.ui.Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally
+    ) {
+        androidx.compose.material3.Text(
+            text = "Home Screen",
+            style = androidx.compose.material3.MaterialTheme.typography.headlineMedium
+        )
+        androidx.compose.material3.Text(
+            text = "Welcome to the home screen!",
+            style = androidx.compose.material3.MaterialTheme.typography.bodyLarge,
+            modifier = androidx.compose.ui.Modifier.padding(top = 8.dp)
+        )
+        
+        androidx.compose.foundation.layout.Spacer(modifier = androidx.compose.ui.Modifier.height(24.dp))
+        
+        // ナビゲーションボタン
+        onNavigateToSwiftUI?.let { navigate ->
+            androidx.compose.material3.Button(
+                onClick = navigate,
+                modifier = androidx.compose.ui.Modifier.padding(8.dp)
+            ) {
+                androidx.compose.material3.Text("Open SwiftUI Screen")
+            }
+        }
+        
+        onNavigateToNative?.let { navigate ->
+            androidx.compose.material3.Button(
+                onClick = navigate,
+                modifier = androidx.compose.ui.Modifier.padding(8.dp)
+            ) {
+                androidx.compose.material3.Text("Open Native Screen")
+            }
+        }
+    }
+}
+
+@Composable
+fun SearchScreen() {
+    androidx.compose.foundation.layout.Column(
+        modifier = androidx.compose.ui.Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally
+    ) {
+        androidx.compose.material3.Text(
+            text = "Search Screen",
+            style = androidx.compose.material3.MaterialTheme.typography.headlineMedium
+        )
+        androidx.compose.material3.Text(
+            text = "Search for content here!",
+            style = androidx.compose.material3.MaterialTheme.typography.bodyLarge,
+            modifier = androidx.compose.ui.Modifier.padding(top = 8.dp)
+        )
+    }
+}
+
+@Composable
+fun ProfileScreen() {
+    androidx.compose.foundation.layout.Column(
+        modifier = androidx.compose.ui.Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally
+    ) {
+        androidx.compose.material3.Text(
+            text = "Profile Screen",
+            style = androidx.compose.material3.MaterialTheme.typography.headlineMedium
+        )
+        androidx.compose.material3.Text(
+            text = "Manage your profile here!",
+            style = androidx.compose.material3.MaterialTheme.typography.bodyLarge,
+            modifier = androidx.compose.ui.Modifier.padding(top = 8.dp)
+        )
+    }
+}
+
+@Composable
+fun SettingsScreen() {
+    androidx.compose.foundation.layout.Column(
+        modifier = androidx.compose.ui.Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally
+    ) {
+        androidx.compose.material3.Text(
+            text = "Settings Screen",
+            style = androidx.compose.material3.MaterialTheme.typography.headlineMedium
+        )
+        androidx.compose.material3.Text(
+            text = "Configure your settings!",
+            style = androidx.compose.material3.MaterialTheme.typography.bodyLarge,
+            modifier = androidx.compose.ui.Modifier.padding(top = 8.dp)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/my/composedemo/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/my/composedemo/SplashScreen.kt
@@ -1,0 +1,119 @@
+package com.my.composedemo
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import composedemo.composeapp.generated.resources.Res
+import composedemo.composeapp.generated.resources.compose_multiplatform
+
+@Composable
+fun SplashScreen(
+    onNavigateToHome: () -> Unit
+) {
+    var isVisible by remember { mutableStateOf(false) }
+    var isLoading by remember { mutableStateOf(true) }
+    
+    // フェードインアニメーション
+    val alpha by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
+        animationSpec = tween(1000),
+        label = "alpha"
+    )
+    
+    // スケールアニメーション
+    val scale by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0.8f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "scale"
+    )
+    
+    // スプラッシュ画面の表示
+    LaunchedEffect(Unit) {
+        isVisible = true
+        delay(2000) // 2秒間表示
+        isLoading = false
+        delay(500) // フェードアウト時間
+        onNavigateToHome()
+    }
+    
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.primary)
+            .alpha(alpha),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            // ロゴ画像
+            Image(
+                painter = painterResource(Res.drawable.compose_multiplatform),
+                contentDescription = "App Logo",
+                modifier = Modifier
+                    .size(120.dp)
+                    .alpha(alpha)
+            )
+            
+            Spacer(modifier = Modifier.height(24.dp))
+            
+            // アプリ名
+            Text(
+                text = "ComposeDemo",
+                style = MaterialTheme.typography.headlineLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 32.sp
+                ),
+                color = MaterialTheme.colorScheme.onPrimary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.alpha(alpha)
+            )
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            // サブタイトル
+            Text(
+                text = "Kotlin Multiplatform App",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.alpha(alpha)
+            )
+            
+            Spacer(modifier = Modifier.height(48.dp))
+            
+            // ローディングインジケーター
+            if (isLoading) {
+                CircularProgressIndicator(
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 3.dp,
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+        }
+    }
+}
+
+// アプリの状態を管理するenum
+enum class AppState {
+    SPLASH,
+    HOME
+}

--- a/composeApp/src/iosMain/kotlin/com/my/composedemo/PlatformNavigation.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/my/composedemo/PlatformNavigation.ios.kt
@@ -1,0 +1,18 @@
+package com.my.composedemo
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlatformNavigation(
+    navigationState: NavigationState,
+    onNavigateToNative: (() -> Unit)?,
+    onNavigateToSwiftUI: (() -> Unit)?
+) {
+    // iOS用の共通ナビゲーションコンテンツを使用
+    // SwiftUIのBottomNavigationはiOS側で処理
+    NavigationContent(
+        navigationState = navigationState,
+        onNavigateToNative = onNavigateToNative,
+        onNavigateToSwiftUI = onNavigateToSwiftUI
+    )
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -41,23 +41,88 @@ struct SwiftUIScreen: View {
     }
 }
 
-struct ContentView: View {
-    @State private var showSwiftUIScreen = false
+struct TabBar: View {
+    @ObservedObject var navigationState: IOSNavigationState
+    let onNavigateToSwiftUI: () -> Void
+    
+    var body: some View {
+        TabView(selection: $navigationState.selectedTab) {
+            ForEach(IOSTabItem.allCases, id: \.rawValue) { tab in
+                TabContentView(
+                    tab: tab,
+                    onNavigateToSwiftUI: onNavigateToSwiftUI
+                )
+                .tabItem {
+                    Image(systemName: tab.icon)
+                    Text(tab.title)
+                }
+                .tag(tab.rawValue)
+            }
+        }
+        .accentColor(.primary)
+        .background(.ultraThinMaterial) // Liquid Glass効果
+        .preferredColorScheme(.light)
+    }
+}
+
+struct TabContentView: View {
+    let tab: IOSTabItem
+    let onNavigateToSwiftUI: () -> Void
     
     var body: some View {
         NavigationView {
-            VStack {
-                ComposeView(onNavigateToSwiftUI: {
-                    showSwiftUIScreen = true
-                })
-                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                Image(systemName: tab.icon)
+                    .font(.system(size: 60))
+                    .foregroundColor(tab.color)
+                
+                Text(tab.title)
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                
+                Text("This is the \(tab.title.lowercased()) screen")
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                
+                // Home画面でのみSwiftUI遷移ボタンを表示
+                if tab == .home {
+                    Button("Open SwiftUI Screen") {
+                        onNavigateToSwiftUI()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding()
+                }
+                
+                Spacer()
             }
-            .sheet(isPresented: $showSwiftUIScreen) {
-                SwiftUIScreen()
-            }
+            .padding()
+            .navigationTitle(tab.title)
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }
 
-
-
+struct ContentView: View {
+    @StateObject private var navigationState = IOSNavigationState()
+    @State private var showSwiftUIScreen = false
+    @State private var showNativeTabBar = false
+    
+    var body: some View {
+        if showNativeTabBar {
+            TabBar(
+                navigationState: navigationState,
+                onNavigateToSwiftUI: {
+                    showSwiftUIScreen = true
+                }
+            )
+            .sheet(isPresented: $showSwiftUIScreen) {
+                SwiftUIScreen()
+            }
+        } else {
+            ComposeView(onNavigateToSwiftUI: {
+                showNativeTabBar = true
+            })
+            .ignoresSafeArea()
+        }
+    }
+}

--- a/iosApp/iosApp/IOSNavigationState.swift
+++ b/iosApp/iosApp/IOSNavigationState.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+
+// iOS側のナビゲーション状態管理
+class IOSNavigationState: ObservableObject {
+    @Published var selectedTab: Int = 0
+    
+    func selectTab(_ tab: Int) {
+        selectedTab = tab
+    }
+}
+
+// iOS側のタブ定義
+enum IOSTabItem: Int, CaseIterable {
+    case home = 0
+    case search = 1
+    case profile = 2
+    case settings = 3
+    
+    var title: String {
+        switch self {
+        case .home: return "Home"
+        case .search: return "Search"
+        case .profile: return "Profile"
+        case .settings: return "Settings"
+        }
+    }
+    
+    var icon: String {
+        switch self {
+        case .home: return "house.fill"
+        case .search: return "magnifyingglass"
+        case .profile: return "person.fill"
+        case .settings: return "gear"
+        }
+    }
+    
+    var color: Color {
+        switch self {
+        case .home: return .blue
+        case .search: return .green
+        case .profile: return .orange
+        case .settings: return .purple
+        }
+    }
+}


### PR DESCRIPTION
- Add splash screen with navigation state management
- Implement Android bottom navigation with Material3 NavigationBar
- Implement iOS TabBar with SwiftUI TabView and liquid glass effect
- Add platform-specific navigation implementations
- Create shared navigation state and content components
- Support navigation between Compose and native screens

Features:
- Android: Material3 NavigationBar with 4 tabs (Home, Search, Profile, Settings)
- iOS: SwiftUI TabView with liquid glass effect and native tab bar
- Cross-platform: Shared navigation state and content
- Hybrid approach: Compose + platform-specific native screens